### PR TITLE
fix(api): call .unique() on Election scalars

### DIFF
--- a/api/app/controllers/base.py
+++ b/api/app/controllers/base.py
@@ -26,7 +26,7 @@ def base_view():
     rv = {"data": dict()}
 
     try:
-        elections = db.session.execute(select(Election)).scalars().all()
+        elections = db.session.execute(select(Election)).scalars().unique().all()
     except SQLAlchemyError as e:
         logger.error(e)
         return json_response({"error": "Server Error"})

--- a/api/app/controllers/election.py
+++ b/api/app/controllers/election.py
@@ -44,7 +44,7 @@ def elections():
         logger.info(f"Cache miss for {request.path}")
 
     try:
-        all_elections = db.session.execute(select(Election)).scalars().all()
+        all_elections = db.session.execute(select(Election)).scalars().unique().all()
     except SQLAlchemyError as e:
         logger.error(e)
         return json_response({"error": "Server Error"})

--- a/api/app/controllers/sitemap.py
+++ b/api/app/controllers/sitemap.py
@@ -19,7 +19,7 @@ def sitemap_view():
         terr = None
         query = db.session.execute(
             select(Election).order_by(Election.territory)
-        ).scalars().all()
+        ).scalars().unique().all()
         for occ in query:
             if occ.territory != terr:
                 yield f"{SITE_ROOT}/wahlen/{occ.territory}/\n"

--- a/api/tests/test_elections.py
+++ b/api/tests/test_elections.py
@@ -5,18 +5,21 @@ def test_elections_list(client):
     r = client.get("/v3/elections/")
     assert r.status_code == 200
     assert r.mimetype == "application/json"
+    assert "error" not in r.get_json()
 
 
 def test_elections_list_with_thesis_data(client):
     r = client.get("/v3/elections/?thesis_data=1")
     assert r.status_code == 200
     assert r.mimetype == "application/json"
+    assert "error" not in r.get_json()
 
 
 def test_specific_election(client):
     r = client.get("/v3/elections/1")
     assert r.status_code == 200
     assert r.mimetype == "application/json"
+    assert "error" not in r.get_json()
 
 
 def test_unknown_election_404(client):


### PR DESCRIPTION
## Summary
- SQLAlchemy 2.0 requires `.unique()` when a scalar query eager-loads a collection via joinedload.
- `Election.results` uses `lazy=\"joined\"`, so `/v3/base`, `/v3/elections/` and `/v3/sitemap.xml` raised `InvalidRequestError` and returned an error envelope in production (with status 200, which is why tests passed).
- Tests now also reject error envelopes, not only non-200 status.

## Test Plan
- [x] `uv run pytest` in CI
- [ ] On helena: pull image and `docker compose restart api`, re-hit `/v3/base`, `/v3/elections/`, `/v3/sitemap.xml`