### PR TITLE
ci: split Release into reusable workflow; drop client image publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
       - run: yarn build
         env:
           REACT_APP_API_ROOT: https://api.metawahl.de/v3
-      - name: Sanity-check client Dockerfile builds
-        working-directory: ${{ github.workspace }}
-        run: docker build --target prod --build-arg REACT_APP_API_ROOT=https://api.metawahl.de/v3 ./client
 
   api:
     runs-on: ubuntu-latest
@@ -97,41 +94,11 @@ jobs:
       - name: Run pytest
         run: uv run pytest -v
 
-  publish:
+  release:
     needs: [lint, client, api]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push api image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: api/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/metawahl-api:latest
-            ghcr.io/${{ github.repository_owner }}/metawahl-api:${{ github.sha }}
-          cache-from: type=gha,scope=api
-          cache-to: type=gha,mode=max,scope=api
-      - name: Build and push client image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./client
-          target: prod
-          build-args: |
-            REACT_APP_API_ROOT=https://api.metawahl.de/v3
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/metawahl-client:latest
-            ghcr.io/${{ github.repository_owner }}/metawahl-client:${{ github.sha }}
-          cache-from: type=gha,scope=client
-          cache-to: type=gha,mode=max,scope=client
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       dry-run:
-        description: "If true, publish + build bundle but skip the deploy to helena"
+        description: "Publish and build, skip deploy to metawahl.de"
         required: false
         default: false
         type: boolean
@@ -15,7 +15,7 @@ on:
         required: false
         default: ""
       dry-run:
-        description: "If true, publish + build bundle but skip the deploy to helena"
+        description: "Publish and build, skip deploy to metawahl.de"
         required: false
         default: false
         type: boolean


### PR DESCRIPTION
## Summary
- Add \`.github/workflows/release.yml\` as a reusable workflow (\`workflow_call\` + \`workflow_dispatch\`): \`publish-api\`, \`build-client-bundle\`, \`deploy\`.
- \`deploy\` uses \`appleboy/scp-action@v1\` to rsync the client bundle to \`/var/www/metawahl/\` on helena and \`appleboy/ssh-action@v1\` to \`docker compose pull api\` + \`up -d\` + \`redis-cli FLUSHALL\` + smoke curl.
- \`ci.yml\`: remove standalone \`publish\` job and the client Dockerfile sanity step. Add a \`release:\` caller (\`uses: ./.github/workflows/release.yml\`, \`secrets: inherit\`), gated on \`needs: [lint, client, api]\` and master push.
- Client image push dropped — helena serves static files from host nginx, container was never consumed. \`ghcr.io/cafca/metawahl-client\` package to be deleted after this lands.

## Test Plan
- [ ] \`gh workflow run release.yml --ref release-workflow -f dry-run=true\` — confirms YAML parses, \`publish-api\` pushes \`:<sha>\`, artifact uploads, \`deploy\` job skipped.
- [ ] \`gh workflow run release.yml --ref release-workflow\` — full dispatch; confirms scp, ssh, \`docker compose pull\`, \`FLUSHALL\`, smoke curls.
- [ ] Post-dispatch: \`curl -fsS https://api.metawahl.de/v3/base\`, \`curl -fsS https://metawahl.de/\`.
- [ ] Secrets set: \`HELENA_SSH_HOST\`, \`HELENA_SSH_USER\`, \`HELENA_SSH_KEY\`, \`HELENA_SSH_PORT\` (optional).