### PR TITLE
ci: fix release deploy scp rm permission error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,14 @@ jobs:
         with:
           name: client-bundle
           path: client-bundle
+      - name: Clean client bundle target on helena
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.HELENA_SSH_HOST }}
+          username: ${{ secrets.HELENA_SSH_USER }}
+          key: ${{ secrets.HELENA_SSH_KEY }}
+          port: ${{ secrets.HELENA_SSH_PORT || 22 }}
+          script: find /var/www/metawahl/ -mindepth 1 -delete
       - name: Rsync client bundle to helena
         uses: appleboy/scp-action@v1
         with:
@@ -100,7 +108,6 @@ jobs:
           target: "/var/www/metawahl/"
           strip_components: 1
           overwrite: true
-          rm: true
       - name: Pull api image + restart + flush cache + smoke
         uses: appleboy/ssh-action@v1
         with:


### PR DESCRIPTION
First full dispatch of release.yml failed on the scp rm step:

\`\`\`
Remove target folder: /var/www/metawahl/
drone-scp error: Process exited with status 1
\`\`\`

Cause: drone-scp's \`rm: true\` runs \`rm -rf /var/www/metawahl/\`. /var/www is root:root drwxrwxr-x (no world write, pv not in root group), so pv can't remove the dir itself even though it owns the dir.

Fix: drop \`rm: true\`; add a pre-scp ssh step that runs \`find /var/www/metawahl/ -mindepth 1 -delete\` — only needs write on the dir itself, which pv has.

## Test plan

- [ ] Merge. Dispatch \`gh workflow run release.yml --ref master\`. Expect green + smoke curls pass.
- [ ] Laptop: \`curl -fsS https://api.metawahl.de/v3/base\` + \`curl -fsS https://metawahl.de/\`.